### PR TITLE
Let user define custom 404 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@ A simple http server to serve static resource files from a local directory.
 
 ## Options
 
-    -h, --help              output usage information
-    -V, --version           output the version number
-    -p, --port <n>          the port to listen to for incoming HTTP connections
-    -i, --index <filename>  the default index file if not specified
-    -f, --follow-symlink    follow links, otherwise fail with file not found
-    -d, --debug             enable to show error messages
+    -h, --help                output usage information
+    -V, --version             output the version number
+    -p, --port <n>            the port to listen to for incoming HTTP connections
+    -i, --index <filename>    the default index file if not specified
+    -f, --follow-symlink      follow links, otherwise fail with file not found
+    -d, --debug               enable to show error messages
+    -e, --error404 <filename> the error 404 file
 
 ## Using as a node module
 
@@ -32,7 +33,8 @@ var server = new StaticServer({
   port: 1337,               // optional, defaults to a random port
   host: '10.0.0.100',       // optional, defaults to any interface
   followSymlink: true,      // optional, defaults to a 404 error
-  index: 'foo.html'         // optional, defaults to 'index.html'
+  index: 'foo.html',        // optional, defaults to 'index.html'
+  error404page: '404.html'  // optional, defaults to undefined
 });
 
 server.start(function () {

--- a/bin/static-server.js
+++ b/bin/static-server.js
@@ -4,6 +4,7 @@ const DEFAULT_PORT = 9080;
 const DEFAULT_INDEX = 'index.html';
 const DEFAULT_FOLLOW_SYMLINKS = false;
 const DEFAULT_DEBUG = false;
+const DEFAULT_ERROR_404 = undefined;
 
 
 var path    = require("path");
@@ -25,6 +26,7 @@ program
   .option('-i, --index <filename>', 'the default index file if not specified', DEFAULT_INDEX)
   .option('-f, --follow-symlink', 'follow links, otherwise fail with file not found', DEFAULT_FOLLOW_SYMLINKS)
   .option('-d, --debug', 'enable to show error messages', DEFAULT_DEBUG)
+  .option('-e, --error404 <filename>', 'the error 404 file', DEFAULT_ERROR_404)
   .parse(process.argv);
 ;
 
@@ -108,4 +110,3 @@ function initTerminateHandlers() {
     process.exit(0);
   });
 }
-

--- a/bin/static-server.js
+++ b/bin/static-server.js
@@ -17,6 +17,8 @@ var pkg     = require(path.join(__dirname, '..', 'package.json'));
 var StaticServer = require('../server.js');
 var server;
 
+var templates = {};
+
 initTerminateHandlers();
 
 program
@@ -26,14 +28,14 @@ program
   .option('-i, --index <filename>', 'the default index file if not specified', DEFAULT_INDEX)
   .option('-f, --follow-symlink', 'follow links, otherwise fail with file not found', DEFAULT_FOLLOW_SYMLINKS)
   .option('-d, --debug', 'enable to show error messages', DEFAULT_DEBUG)
-  .option('-e, --error404 <filename>', 'the error 404 file', DEFAULT_ERROR_404)
+  .option('-n, --not-found <filename>', 'the file not found template', addNotFoundTemplate, DEFAULT_ERROR_404)
   .parse(process.argv);
 ;
 
 // overrides
 program.rootPath = program.args[0] || process.cwd();
 program.name = pkg.name;
-
+program.templates = templates;
 
 server = new StaticServer(program);
 
@@ -109,4 +111,8 @@ function initTerminateHandlers() {
     console.log(chalk.blue.bold('!'), chalk.yellow.bold('SIGTERM'), 'detected');
     process.exit(0);
   });
+}
+
+function addNotFoundTemplate(v){
+  templates.notFound = v;
 }

--- a/server.js
+++ b/server.js
@@ -148,7 +148,7 @@ function requestHandler(server) {
             }else{
               sendFile(server, req, res, stat, file);
             }
-          })
+          });
         }else{
           sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
         }

--- a/server.js
+++ b/server.js
@@ -141,17 +141,7 @@ function requestHandler(server) {
 
     getFileStats(server, [filename, path.join(filename, server.index)], function (err, stat, file, index) {
       if (err) {
-        if(server.error404page){
-          getFileStats(server, [server.error404page], function(err, stat, file, index){
-            if(err){
-              sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
-            }else{
-              sendFile(server, req, res, stat, file);
-            }
-          });
-        }else{
-          sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
-        }
+        handleError(err);
       } else if (stat.isDirectory()) {
         //
         // TODO : handle directory listing here
@@ -162,6 +152,28 @@ function requestHandler(server) {
       }
     });
   };
+}
+
+
+/**
+Handle an error
+
+Currently assumes that the only error would be a 404 error.
+
+@param err {Object} the error to handle
+*/
+function handeError(err){
+  if(server.error404page){
+    getFileStats(server, [server.error404page], function(err, stat, file, index){
+      if(err){
+        sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
+      }else{
+        sendFile(server, req, res, stat, file);
+      }
+    });
+  }else{
+    sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
+  }
 }
 
 

--- a/server.js
+++ b/server.js
@@ -50,6 +50,7 @@ Options are :
    - rootPath      the serving root path. Any file above that path will be denied
    - followSymlink true to follow any symbolic link, false to forbid
    - index         the default index file to server for a directory (default 'index.html')
+   - error404page  the file to send for a 404 error.
 
 @param options {Object}
 */

--- a/server.js
+++ b/server.js
@@ -63,6 +63,7 @@ function StaticServer(options) {
   this.name = options.name;
   this.host = options.host;
   this.port = options.port;
+  this.error404page = options.error404page
   this.rootPath = path.resolve(options.rootPath);
   this.followSymlink = !!options.followSymlink;
   this.index = options.index || DEFAULT_INDEX;
@@ -139,7 +140,17 @@ function requestHandler(server) {
 
     getFileStats(server, [filename, path.join(filename, server.index)], function (err, stat, file, index) {
       if (err) {
-        sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
+        if(server.error404page){
+          getFileStats(server, [server.error404page], function(err, stat, file, index){
+            if(err){
+              sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
+            }else{
+              sendFile(server, req, res, stat, file);
+            }
+          })
+        }else{
+          sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
+        }
       } else if (stat.isDirectory()) {
         //
         // TODO : handle directory listing here

--- a/server.js
+++ b/server.js
@@ -175,9 +175,10 @@ Currently assumes that the only error would be a 404 error.
 function handleError(server, req, res, err){
   if(server.templates.notFound){
     getFileStats(server, [server.templates.notFound], function(err, stat, file, index){
-      if(err){
+      if (err) {
         sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
-      }else{
+      } else {
+        res.status = HTTP_STATUS_NOT_FOUND;
         sendFile(server, req, res, stat, file);
       }
     });
@@ -485,10 +486,12 @@ function sendFile(server, req, res, stat, file) {
           }
         }).on('open', function (fd) {
           if (!headersSent) {
-            if (range) {
-              res.status = HTTP_STATUS_PARTIAL_CONTENT;
-            } else {
-              res.status = HTTP_STATUS_OK;
+            if (!res.status){
+              if (range) {
+                res.status = HTTP_STATUS_PARTIAL_CONTENT;
+              } else {
+                res.status = HTTP_STATUS_OK;
+              }
             }
             res.writeHead(res.status, res.headers);
             headersSent = true;

--- a/server.js
+++ b/server.js
@@ -160,7 +160,9 @@ Handle an error
 
 Currently assumes that the only error would be a 404 error.
 
-@param server {StaticServer}  server instance
+@param server {StaticServer} server instance
+@param req {Object} request Object
+@param res {Object} response Object
 @param err {Object} the error to handle
 */
 function handleError(server, req, res, err){

--- a/server.js
+++ b/server.js
@@ -141,7 +141,7 @@ function requestHandler(server) {
 
     getFileStats(server, [filename, path.join(filename, server.index)], function (err, stat, file, index) {
       if (err) {
-        handleError(err);
+        handleError(server, req, res, err);
       } else if (stat.isDirectory()) {
         //
         // TODO : handle directory listing here
@@ -160,9 +160,10 @@ Handle an error
 
 Currently assumes that the only error would be a 404 error.
 
+@param server {StaticServer}  server instance
 @param err {Object} the error to handle
 */
-function handeError(err){
+function handleError(server, req, res, err){
   if(server.error404page){
     getFileStats(server, [server.error404page], function(err, stat, file, index){
       if(err){

--- a/server.js
+++ b/server.js
@@ -50,7 +50,8 @@ Options are :
    - rootPath      the serving root path. Any file above that path will be denied
    - followSymlink true to follow any symbolic link, false to forbid
    - index         the default index file to server for a directory (default 'index.html')
-   - error404page  the file to send for a 404 error.
+   - templates
+      - notFound   the 404 error template
 
 @param options {Object}
 */
@@ -61,13 +62,19 @@ function StaticServer(options) {
     throw new Error('Root path not specified');
   }
 
+  if(!options.templates){
+    options.templates = {};
+  }
+
   this.name = options.name;
   this.host = options.host;
   this.port = options.port;
-  this.error404page = options.error404page
   this.rootPath = path.resolve(options.rootPath);
   this.followSymlink = !!options.followSymlink;
   this.index = options.index || DEFAULT_INDEX;
+  this.templates = {
+    'notFound': options.templates.notFound
+  };
 
   Object.defineProperty(this, '_socket', {
     configurable: true,
@@ -166,8 +173,8 @@ Currently assumes that the only error would be a 404 error.
 @param err {Object} the error to handle
 */
 function handleError(server, req, res, err){
-  if(server.error404page){
-    getFileStats(server, [server.error404page], function(err, stat, file, index){
+  if(server.templates.notFound){
+    getFileStats(server, [server.templates.notFound], function(err, stat, file, index){
       if(err){
         sendError(server, req, res, null, HTTP_STATUS_NOT_FOUND);
       }else{

--- a/test/fixtures/404.html
+++ b/test/fixtures/404.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+  </head>
+  <body>
+    <h1>Error 404</h1>
+  </body>
+</html>

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -47,6 +47,25 @@ describe('StaticServer test', function () {
     ;
   });
 
+  it('should show a 404 page if configured to', function(done){
+    testServer404 = new Server({
+      rootPath: path.join(__dirname, 'fixtures'),
+      error404page: path.join(__dirname, 'fixtures', '404.html')
+    })
+
+    testServer404.start(function(){
+      request(testServer404._socket)
+        .get('/foo.html')
+        .expect(200)
+        .expect(/<h1>Error 404<\/h1>/)
+        .end(function(err, res){
+          if(err){ throw err }
+          testServer404.stop()
+          done()
+        })
+    })
+  })
+
   it('should handle index', function (done) {
     var oldIndex = testServer.index;
     testServer.index = 'test.html';

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -52,7 +52,7 @@ describe('StaticServer test', function () {
 
     request(testServer._socket)
       .get('/foo.html')
-      .expect(200)
+      .expect(404)
       .expect(/<h1>Error 404<\/h1>/)
       .end(function(err, res){
         testServer.templates.notFound = undefined;

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -55,9 +55,8 @@ describe('StaticServer test', function () {
       .expect(200)
       .expect(/<h1>Error 404<\/h1>/)
       .end(function(err, res){
-        if(err){ throw err }
         testServer.error404page = undefined
-        done()
+        done(err)
       })
   })
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -48,22 +48,17 @@ describe('StaticServer test', function () {
   });
 
   it('should show a 404 page if configured to', function(done){
-    testServer404 = new Server({
-      rootPath: path.join(__dirname, 'fixtures'),
-      error404page: path.join(__dirname, 'fixtures', '404.html')
-    })
+    testServer.error404page = path.join(__dirname, 'fixtures', '404.html')
 
-    testServer404.start(function(){
-      request(testServer404._socket)
-        .get('/foo.html')
-        .expect(200)
-        .expect(/<h1>Error 404<\/h1>/)
-        .end(function(err, res){
-          if(err){ throw err }
-          testServer404.stop()
-          done()
-        })
-    })
+    request(testServer._socket)
+      .get('/foo.html')
+      .expect(200)
+      .expect(/<h1>Error 404<\/h1>/)
+      .end(function(err, res){
+        if(err){ throw err }
+        testServer.error404page = undefined
+        done()
+      })
   })
 
   it('should handle index', function (done) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -48,26 +48,26 @@ describe('StaticServer test', function () {
   });
 
   it('should show a 404 page if configured to', function(done){
-    testServer.error404page = path.join(__dirname, 'fixtures', '404.html');
+    testServer.templates.notFound = path.join(__dirname, 'fixtures', '404.html');
 
     request(testServer._socket)
       .get('/foo.html')
       .expect(200)
       .expect(/<h1>Error 404<\/h1>/)
       .end(function(err, res){
-        testServer.error404page = undefined;
+        testServer.templates.notFound = undefined;
         done(err);
       });
   })
 
   it('should throw 404 page if configured page does not exist', function(done){
-    testServer.error404page = path.join(__dirname, 'fixtures', 'missing.html');
+    testServer.templates.notFound = path.join(__dirname, 'fixtures', 'missing.html');
 
     request(testServer._socket)
       .get('/foo.html')
       .expect(404)
       .end(function(err, res){
-        testServer.error404page = undefined;
+        testServer.templates.notFound = undefined;
         done(err);
       });
   })

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -48,16 +48,28 @@ describe('StaticServer test', function () {
   });
 
   it('should show a 404 page if configured to', function(done){
-    testServer.error404page = path.join(__dirname, 'fixtures', '404.html')
+    testServer.error404page = path.join(__dirname, 'fixtures', '404.html');
 
     request(testServer._socket)
       .get('/foo.html')
       .expect(200)
       .expect(/<h1>Error 404<\/h1>/)
       .end(function(err, res){
-        testServer.error404page = undefined
-        done(err)
-      })
+        testServer.error404page = undefined;
+        done(err);
+      });
+  })
+
+  it('should throw 404 page if configured page does not exist', function(done){
+    testServer.error404page = path.join(__dirname, 'fixtures', 'missing.html');
+
+    request(testServer._socket)
+      .get('/foo.html')
+      .expect(404)
+      .end(function(err, res){
+        testServer.error404page = undefined;
+        done(err);
+      });
   })
 
   it('should handle index', function (done) {


### PR DESCRIPTION
I use static-server in my [Jekyll-Atom](https://github.com/Arcath/jekyll-atom) plugin to host a preview of the Jekyll site. Something I want to try needs my preview server to send 404 errors to my 404.html (like Github Pages does).

This PR adds the `error404page` option to static-server so that users can define how to handle 404 errors instead of just sending a 404 status.