### PR TITLE
Index template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ A simple http server to serve static resource files from a local directory.
 
 ## Options
 
-    -h, --help                output usage information
-    -V, --version             output the version number
-    -p, --port <n>            the port to listen to for incoming HTTP connections
-    -i, --index <filename>    the default index file if not specified
-    -f, --follow-symlink      follow links, otherwise fail with file not found
-    -d, --debug               enable to show error messages
-    -e, --error404 <filename> the error 404 file
+    -h, --help                 output usage information
+    -V, --version              output the version number
+    -p, --port <n>             the port to listen to for incoming HTTP connections
+    -i, --index <filename>     the default index file if not specified
+    -f, --follow-symlink       follow links, otherwise fail with file not found
+    -d, --debug                enable to show error messages
+    -n, --not-found <filename> the error 404 file
 
 ## Using as a node module
 
@@ -33,8 +33,10 @@ var server = new StaticServer({
   port: 1337,               // optional, defaults to a random port
   host: '10.0.0.100',       // optional, defaults to any interface
   followSymlink: true,      // optional, defaults to a 404 error
-  index: 'foo.html',        // optional, defaults to 'index.html'
-  error404page: '404.html'  // optional, defaults to undefined
+  templates: {
+    index: 'foo.html',      // optional, defaults to 'index.html'
+    notFound: '404.html'    // optional, defaults to undefined
+  }
 });
 
 server.start(function () {

--- a/bin/static-server.js
+++ b/bin/static-server.js
@@ -25,7 +25,7 @@ program
   .version(pkg.name + '@' + pkg.version)
   .usage('[options] <root_path>')
   .option('-p, --port <n>', 'the port to listen to for incoming HTTP connections', DEFAULT_PORT)
-  .option('-i, --index <filename>', 'the default index file if not specified', DEFAULT_INDEX)
+  .option('-i, --index <filename>', 'the default index file if not specified', addIndexTemplate, DEFAULT_INDEX)
   .option('-f, --follow-symlink', 'follow links, otherwise fail with file not found', DEFAULT_FOLLOW_SYMLINKS)
   .option('-d, --debug', 'enable to show error messages', DEFAULT_DEBUG)
   .option('-n, --not-found <filename>', 'the file not found template', addNotFoundTemplate, DEFAULT_ERROR_404)
@@ -115,4 +115,8 @@ function initTerminateHandlers() {
 
 function addNotFoundTemplate(v){
   templates.notFound = v;
+}
+
+function addIndexTemplate(v){
+  templates.index = v;
 }

--- a/server.js
+++ b/server.js
@@ -71,10 +71,15 @@ function StaticServer(options) {
   this.port = options.port;
   this.rootPath = path.resolve(options.rootPath);
   this.followSymlink = !!options.followSymlink;
-  this.index = options.index || DEFAULT_INDEX;
   this.templates = {
+    'index': (options.templates.index || DEFAULT_INDEX),
     'notFound': options.templates.notFound
   };
+
+  if (options.index) {
+    console.log("options.index is now deprecated please use options.templates.index instead.")
+    this.templates.index = options.index
+  }
 
   Object.defineProperty(this, '_socket', {
     configurable: true,
@@ -146,7 +151,7 @@ function requestHandler(server) {
       return sendError(server, req, res, null, HTTP_STATUS_FORBIDDEN);
     }
 
-    getFileStats(server, [filename, path.join(filename, server.index)], function (err, stat, file, index) {
+    getFileStats(server, [filename, path.join(filename, server.templates.index)], function (err, stat, file, index) {
       if (err) {
         handleError(server, req, res, err);
       } else if (stat.isDirectory()) {

--- a/server.js
+++ b/server.js
@@ -49,8 +49,8 @@ Options are :
    - port          the listening port number
    - rootPath      the serving root path. Any file above that path will be denied
    - followSymlink true to follow any symbolic link, false to forbid
-   - index         the default index file to server for a directory (default 'index.html')
    - templates
+      - index      the default index file to server for a directory (default 'index.html')
       - notFound   the 404 error template
 
 @param options {Object}
@@ -77,8 +77,8 @@ function StaticServer(options) {
   };
 
   if (options.index) {
-    console.log("options.index is now deprecated please use options.templates.index instead.")
-    this.templates.index = options.index
+    console.log("options.index is now deprecated please use options.templates.index instead.");
+    this.templates.index = options.index;
   }
 
   Object.defineProperty(this, '_socket', {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -34,7 +34,7 @@ describe('StaticServer test', function () {
     assert.equal(testServer.port, undefined);
 
     testServer.followSymlink.should.be.false;
-    testServer.index.should.equal('index.html');
+    testServer.templates.index.should.equal('index.html');
 
     testServer.should.have.ownProperty('_socket');
   });
@@ -74,7 +74,7 @@ describe('StaticServer test', function () {
 
   it('should handle index', function (done) {
     var oldIndex = testServer.index;
-    testServer.index = 'test.html';
+    testServer.templates.index = 'test.html';
 
     request(testServer._socket)
       .get('/')


### PR DESCRIPTION
As suggested in #15 this moves the index into the templates object and has a little console message to warn users that `options.index` has been deprecated.