### PR TITLE
Allow cors header to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ var server = new StaticServer({
   name: 'my-http-server',   // optional, will set "X-Powered-by" HTTP header
   port: 1337,               // optional, defaults to a random port
   host: '10.0.0.100',       // optional, defaults to any interface
+  cors: '*'                 // optional, defaults to undefined
   followSymlink: true,      // optional, defaults to a 404 error
   index: 'foo.html',        // optional, defaults to 'index.html'
   error404page: '404.html'  // optional, defaults to undefined

--- a/server.js
+++ b/server.js
@@ -46,6 +46,7 @@ Options are :
    - name          the server name, what will be sent as "X-Powered-by"
    - host          the host interface where the server will listen to. If not specified,
                    the server will listen on any networking interfaces
+   - cors          a cors header, will be sent as "Access-Control-Allow-Origin",
    - port          the listening port number
    - rootPath      the serving root path. Any file above that path will be denied
    - followSymlink true to follow any symbolic link, false to forbid
@@ -69,6 +70,7 @@ function StaticServer(options) {
   this.name = options.name;
   this.host = options.host;
   this.port = options.port;
+  this.cors = options.cors;
   this.rootPath = path.resolve(options.rootPath);
   this.followSymlink = !!options.followSymlink;
   this.index = options.index || DEFAULT_INDEX;

--- a/server.js
+++ b/server.js
@@ -138,6 +138,10 @@ function requestHandler(server) {
       res.headers['X-Powered-By'] = server.name;
     }
 
+    if (server.cors) {
+      res.headers['Access-Control-Allow-Origin'] = server.cors;
+    }
+
     server.emit('request', req);
 
     if (VALID_HTTP_METHODS.indexOf(req.method) === -1) {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -32,6 +32,7 @@ describe('StaticServer test', function () {
     assert.equal(testServer.name, undefined);
     assert.equal(testServer.host, undefined);
     assert.equal(testServer.port, undefined);
+    assert.equal(testServer.cors, undefined);
 
     testServer.followSymlink.should.be.false;
     testServer.index.should.equal('index.html');
@@ -145,6 +146,23 @@ describe('StaticServer test', function () {
     it('should follow');
 
   });
+
+  describe('setting \'cors\' option', function () {
+      before(function (done) {
+        var opt = serverOptions
+        opt.cors = '*'
+        testServer = new Server(opt);
+        testServer.start(done);
+      })
+
+      it('should set Access-Control-Allow-Origin', function (done) {
+        request(testServer._socket)
+          .get('/test.js')
+          .expect(200)
+          .expect('Access-Control-Allow-Origin', '*')
+          .end(done)
+      });
+  })
 
 
 });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -40,7 +40,7 @@ describe('StaticServer test', function () {
     testServer.should.have.ownProperty('_socket');
   });
 
-  it('should handle 404 requests', function (done) {
+  it('should handle 403 requests', function (done) {
     request(testServer._socket)
       .get('/')
       .expect(403)


### PR DESCRIPTION
Basically I needed to set basic cors stuff to the headers. For now a simple `cors` option would be fine.

```
{
   rootPath: '.',
   cors: '*'
}
```

This will only add `Access-Control-Allow-Origin` with the value of the `cors` option. Given the nature of this package and the fact that is properly is used mainly for development purposes I think this is fair.

Tell me what you think...