### PR TITLE
Integrate TravisBuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
   webhooks:
       urls:
         - https://www.travisbuddy.com/
-        - http://hooks.mydomain.com/events
       on_success: never
       on_failure: always
       on_start: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,13 @@ node_js:
 matrix:
   fast_finish: true
 script: "npm run-script test-travis"
+notifications:
+  webhooks:
+      urls:
+        - https://www.travisbuddy.com/
+        - http://hooks.mydomain.com/events
+      on_success: never
+      on_failure: always
+      on_start: never
+      on_cancel: never
+      on_error: never


### PR DESCRIPTION
TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contirbutors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed.

Here's an example: https://github.com/bluzi/static-server/pull/1