### PR TITLE
Fixed crash when serves file that resolved by symbol link

### DIFF
--- a/server.js
+++ b/server.js
@@ -266,7 +266,7 @@ function getFileStats(server, files, callback) {
               if (!path.isAbsolute(fileRef)) {
                 fileRef = path.join( path.dirname(file), fileRef );
               }
-              server.emit('symbolicLink', fileRef);
+              server.emit('symbolicLink', file, fileRef);
               next(fileRef, index);
             }
           });


### PR DESCRIPTION
Server crashes when try to log a info about symbol link.

This is caused by an incorrect number of params. See [static-server.js#L60](/nbluis/static-server/blob/master/bin/static-server.js#L60)


UPD

Issue #19 