### PR TITLE
Add new 'intercept' callback, plus related testing and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ server.start(function () {
   console.log('Server listening to', server.port);
 });
 
+server.on('intercept', function (req, res) {
+  // The request `req` can be modified here before being processed,
+  // such as by modifying `req.url`.
+  // Set `req.handled` to `true` to fully handle the request here
+  // instead of responding with a static file.
+});
+
 server.on('request', function (req, res) {
   // req.path is the URL resource (file name) from server.rootPath
   // req.elapsedTime returns a string of the request's elapsed time

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "static-server",
   "description": "A simple http server to serve static resource files from a local directory.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": "Eduardo Bohrer <nbluisrs@gmail.com>",
   "keywords": [
     "static",

--- a/server.js
+++ b/server.js
@@ -137,6 +137,15 @@ Return the server's request handler function
 */
 function requestHandler(server) {
   return function handler(req, res) {
+    var originalUrl = req.url;
+  
+    server.emit('intercept', req, res);
+
+    if (req.handled) {
+      return;
+    }
+
+    var urlModified = req.url !== originalUrl;
     var uri = req.path = decodeURIComponent(url.parse(req.url).pathname);
     var filename = path.join(server.rootPath, uri);
     var timestamp = process.hrtime();
@@ -162,7 +171,7 @@ function requestHandler(server) {
 
     if (VALID_HTTP_METHODS.indexOf(req.method) === -1) {
       return sendError(server, req, res, null, HTTP_STATUS_INVALID_METHOD);
-    } else if (!validPath(server.rootPath, filename)) {
+    } else if (!urlModified && !validPath(server.rootPath, filename)) {
       return sendError(server, req, res, null, HTTP_STATUS_FORBIDDEN);
     }
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -88,6 +88,44 @@ describe('StaticServer test', function () {
     ;
   });
 
+  it('should handle intercept path redirect', function (done) {
+    var intercept = function (req) {
+      req.url = '/test.html'
+    };
+
+    testServer.on('intercept', intercept);
+
+    request(testServer._socket)
+      .get('/foo.html')
+      .expect(200)
+      .end(function (err) {
+        testServer.off('intercept', intercept);
+        done(err);
+      })
+    ;
+  });
+
+  it('should handle intercept takeover', function (done) {
+    var intercept = function (req, res) {
+      req.handled = true;
+      res.writeHead(200);
+      res.write('intercepted!');
+      res.end();
+    };
+
+    testServer.on('intercept', intercept);
+
+    request(testServer._socket)
+      .get('/anything')
+      .expect(200)
+      .expect('intercepted!')
+      .end(function (err) {
+        testServer.off('intercept', intercept);
+        done(err);
+      })
+    ;
+  });
+
   it('should accept HEAD requests');
 
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -89,41 +89,43 @@ describe('StaticServer test', function () {
   });
 
   it('should handle intercept path redirect', function (done) {
-    var intercept = function (req) {
-      req.url = '/test.html'
-    };
+    var testServer = new Server(serverOptions);
+    testServer.start(function () {
+      var intercept = function (req) {
+        req.url = '/test.html'
+      };
 
-    testServer.on('intercept', intercept);
+      testServer.on('intercept', intercept);
 
-    request(testServer._socket)
-      .get('/foo.html')
-      .expect(200)
-      .end(function (err) {
-        testServer.off('intercept', intercept);
-        done(err);
-      })
-    ;
+      request(testServer._socket)
+        .get('/foo.html')
+        .expect(200)
+        .end(function (err) {
+          done(err);
+        });
+      });
   });
 
   it('should handle intercept takeover', function (done) {
-    var intercept = function (req, res) {
-      req.handled = true;
-      res.writeHead(200);
-      res.write('intercepted!');
-      res.end();
-    };
+    var testServer = new Server(serverOptions);
+    testServer.start(function () {
+      var intercept = function (req, res) {
+        req.handled = true;
+        res.writeHead(200);
+        res.write('intercepted!');
+        res.end();
+      };
 
-    testServer.on('intercept', intercept);
+      testServer.on('intercept', intercept);
 
-    request(testServer._socket)
-      .get('/anything')
-      .expect(200)
-      .expect('intercepted!')
-      .end(function (err) {
-        testServer.off('intercept', intercept);
-        done(err);
-      })
-    ;
+      request(testServer._socket)
+        .get('/anything')
+        .expect(200)
+        .expect('intercepted!')
+        .end(function (err) {
+          done(err);
+        });
+      });
   });
 
   it('should accept HEAD requests');


### PR DESCRIPTION
I found your static-server package a great way to create a simple test server for a project I'm working on, but I wanted to be able to redirect where one file was loaded from (a script file that was being tested, located outside the root directory for the static files used for the test), and to process one POST request that shouldn't be treated as a static file request.

With the small change I'm suggesting here, those kinds of things became easy to do, without adding much fuss or complication to what I know is meant to remain a very simple server.