### PR TITLE
Move some options to a child object

### DIFF
--- a/bin/static-server.js
+++ b/bin/static-server.js
@@ -20,18 +20,16 @@ var pkg     = require(path.join(__dirname, '..', 'package.json'));
 var StaticServer = require('../server.js');
 var server;
 
-var templates = {};
-
 initTerminateHandlers();
 
 program
   .version(pkg.name + '@' + pkg.version)
   .usage('[options] <root_path>')
   .option('-p, --port <n>', 'the port to listen to for incoming HTTP connections', DEFAULT_PORT)
-  .option('-i, --index <filename>', 'the default index file if not specified', addIndexTemplate, DEFAULT_INDEX)
+  .option('-i, --index <filename>', 'the default index file if not specified', DEFAULT_INDEX)
   .option('-f, --follow-symlink', 'follow links, otherwise fail with file not found', DEFAULT_FOLLOW_SYMLINKS)
   .option('-d, --debug', 'enable to show error messages', DEFAULT_DEBUG)
-  .option('-n, --not-found <filename>', 'the file not found template', addNotFoundTemplate, DEFAULT_ERROR_404)
+  .option('-n, --not-found <filename>', 'the file not found template', DEFAULT_ERROR_404)
   .option('-c, --cors <pattern>', 'Cross Origin Pattern. Use "*" to allow all origins', DEFAULT_CORS)
   .option('-z, --no-cache', 'disable cache (http 304) responses', DEFAULT_CACHE)
   .option('-o, --open', 'open server in the local browser', DEFAULT_OPEN)
@@ -41,7 +39,12 @@ program
 // overrides
 program.rootPath = program.args[0] || process.cwd();
 program.name = pkg.name;
-program.templates = templates;
+program.templates = { 
+  index: program.index, 
+  notFound: program.notFound
+};
+delete program.index;
+delete program.notFound;
 
 server = new StaticServer(program);
 
@@ -117,12 +120,4 @@ function initTerminateHandlers() {
     console.log(chalk.blue.bold('!'), chalk.yellow.bold('SIGTERM'), 'detected');
     process.exit(0);
   });
-}
-
-function addNotFoundTemplate(v){
-  templates.notFound = v;
-}
-
-function addIndexTemplate(v){
-  templates.index = v;
 }


### PR DESCRIPTION
The fields `options.notFound` and `options.index` are deprecated (since c997ae3e44e5949a9f502c1ae778c84276422ef3)
Should be `options.template.notFound` and `options.template.index`.

Move them from where commander puts them, into the `template` object.

Proposed to fix #52