### PR TITLE
Add CLI option to configure host

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ A simple http server to serve static resource files from a local directory.
     -h, --help                 output usage information
     -V, --version              output the version number
     -p, --port <n>             the port to listen to for incoming HTTP connections
+    -a, --host <address>       the host address to bind to, defaults to all
     -i, --index <filename>     the default index file if not specified
     -f, --follow-symlink       follow links, otherwise fail with file not found
     -d, --debug                enable to show error messages
     -n, --not-found <filename> the error 404 file
     -c, --cors <pattern>       Cross Origin Pattern. Use "*" to allow all origins
-    -z, --no-cache           disable cache (http 304) responses.
+    -z, --no-cache             disable cache (http 304) responses.
     -o, --open                 open server in the local browser
 
 ## Using as a node module

--- a/bin/static-server.js
+++ b/bin/static-server.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const DEFAULT_PORT = 9080;
+const DEFAULT_HOST = undefined;
 const DEFAULT_INDEX = 'index.html';
 const DEFAULT_FOLLOW_SYMLINKS = false;
 const DEFAULT_DEBUG = false;
@@ -28,6 +29,7 @@ program
   .version(pkg.name + '@' + pkg.version)
   .usage('[options] <root_path>')
   .option('-p, --port <n>', 'the port to listen to for incoming HTTP connections', DEFAULT_PORT)
+  .option('-a, --host <address>', 'the host address to bind to, defaults to all', DEFAULT_HOST)
   .option('-i, --index <filename>', 'the default index file if not specified', addIndexTemplate, DEFAULT_INDEX)
   .option('-f, --follow-symlink', 'follow links, otherwise fail with file not found', DEFAULT_FOLLOW_SYMLINKS)
   .option('-d, --debug', 'enable to show error messages', DEFAULT_DEBUG)


### PR DESCRIPTION
Implements #24 (add host option to CLI)

Often when performing quick local tests, it is desirable for the server to be unavailable on the local network for security reasons. This can be managed with a firewall, but that is awkward. This PR exposes the ability to configure a host to fix this.

Example usage:

```shell
static-server --host localhost --port 8080
```

Note that I have not been able to build this project locally due to issues installing dependencies (seems to hang while trying to resolve handlebars for some reason), so I cannot confirm it is working correctly, but I based the code on the existing `port` configuration and see no reason for it to be different.

For the shorthand I chose `-a` for "address" since `-h` is already taken for "help"